### PR TITLE
Add github default files

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Create a report to fix a bug
+---
+
+### Description
+<!-- Briefly describe the issue you're experiencing -->
+
+### Steps to reproduce
+<!-- what you were trying to do and what happened instead. -->
+1.
+1.
+
+### Which pipeline, environment and application did you use?
+<!-- Lumint / Currency Management Application -->
+<!-- Production / Staging / ReviewApp -->
+<!-- Production / Parallel / Demo / ... -->
+
+### Supporting data
+<!-- Do you have screenshots showing the problem? -->
+<!-- Do you see errors in the dev console? If yes, please include a screenshot. -->

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: Suggest an idea or ask for a new feature
+---
+
+### Motivation
+<!-- Your motivation behind this feature request. Stating any specific business reason will help everyone in the team to understand the driver. -->
+
+### Details
+<!-- Please describe this new feature in detail. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+# PULL_REQUEST_TEMPLATE
+
+This PR closes #x, by:
+
+* Adding ...
+* Updating ...
+* Fixing ...
+* ...
+
+**Extra:**
+
+1. Any extra information
+1. Any other extra information
+* ...
+
+<!-- Considerations: -->
+<!-- 1. PR Title Convention: (Feature|Bug|Chore) Task Name -->
+<!-- 1. Be as descriptive as possible, assisting reviewers as much as possible. -->
+<!-- 1. If frontend, paste screenshots that display the UI changes. -->
+<!-- 1. If there is interactivity, paste a gif showing the feature. -->


### PR DESCRIPTION
Aiming for issues and pull requests standardisation across organization, this PR adds github default files. 

More info on this topic: [Creating a default community health file for your organization](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization)